### PR TITLE
Fix focusable hidden element

### DIFF
--- a/src/client/App/MainInstruction/styles.module.css
+++ b/src/client/App/MainInstruction/styles.module.css
@@ -15,4 +15,5 @@
 .instructions > [aria-hidden='true'] {
   opacity: 0;
   pointer-events: none;
+  visibility: hidden;
 }


### PR DESCRIPTION
I was tabbing through the site when I landed on an element that wasn't visible. It was the Wordle link inside this hidden div.

Adding `visibility: hidden` makes it non-focusable. :)

https://kittygiraudel.com/2021/02/17/hiding-content-responsibly/